### PR TITLE
Fix the forgotten version bump

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func getCgroupsVersion() string {
 
 func main() {
 	APPNAME := "cgrpuser-exporter"
-	VERSION := "0.1.1"
+	VERSION := "0.1.2"
 
 	port, timeout := parseArgs(APPNAME, VERSION)
 


### PR DESCRIPTION
Messed up by not bumping the version to `0.1.2`, thus Ansible failed to recognize that the new version was installed successfully.